### PR TITLE
service arm_mover/safe_move expects 2 floats for joint_1 and joint_2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Open a new terminal and type the following:
 ```sh
 $ cd /home/workspace/catkin_ws/
 $ source devel/setup.bash
-$ rosservice call /arm_mover/safe_move 1.0 1.0
+$ rosservice call /arm_mover/safe_move 0.0 0.0
 ```
 
 ## How to view image stream from the camera?

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Open a new terminal and type the following:
 ```sh
 $ cd /home/workspace/catkin_ws/
 $ source devel/setup.bash
-$ rosservice call /arm_mover/safe_move "joint_1: 0.0 joint_2: 0.0"
+$ rosservice call /arm_mover/safe_move 1.0 1.0
 ```
 
 ## How to view image stream from the camera?


### PR DESCRIPTION
Current command produces this error: 
```
File "/usr/lib/python2.7/dist-packages/yaml/scanner.py", line 576, in fetch_value
    self.get_mark())
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<string>", line 1, column 22:
    joint_1: 1.57 joint_2: 1.57
```